### PR TITLE
Improve Actions

### DIFF
--- a/.github/workflows/dumpData.yml
+++ b/.github/workflows/dumpData.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
   schedule:
     - cron: "*/5 * * * *"

--- a/.github/workflows/dumpData.yml
+++ b/.github/workflows/dumpData.yml
@@ -6,21 +6,20 @@ on:
       - main
 
   schedule:
-    - cron: "*/11 * * * *"
+    - cron: "*/5 * * * *"
 
 jobs:
   dumpData:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: main
-          fetch-depth: 1
+        uses: actions/checkout@v4
+
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.x"
+          cache: 'pip'
 
       - working-directory: cache
         name: Install dependencies
@@ -28,7 +27,7 @@ jobs:
 
       - working-directory: cache
         name: Dump Data
-        run: python main.py
+        run: python3 main.py
 
       - name: Commit and Push changes
         run: |

--- a/.github/workflows/dumpData.yml
+++ b/.github/workflows/dumpData.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
           cache: 'pip'


### PR DESCRIPTION
Improvements:
1. Changed action cron to run **every 5 minutes.** From my experience with GitHub Actions cron, it is not very reliable and will run every 10 to 20 minutes anyway even if you set it to 5 minutes. Thus I suggest you use the most frequent option available, which is once every 5 minutes.
2. Upgrade **actions/checkout** to **v4**. Apart from being a newer version, it also uses the flags you set manually like `ref: main` or `fetch-depth: 1` by default. So, I suggest you should just use this as is.
3. Upgrade **actions/setup-python** to **v4** and **cache pip**. You should always cache dependencies as this improves the runtime of actions significantly.
4. Add `workflow_dispatch:`. This enables you to manually run the workflow when you want.